### PR TITLE
Properly handle multiple child connections

### DIFF
--- a/sock_events.c
+++ b/sock_events.c
@@ -85,7 +85,8 @@ void sock_ev_accept(int fd, int ret, int err, struct sockaddr *addr,
 {
 	if (ret < 0)
 		return;
-	udtrace_add_fd(ret);
+	LOG("accept(fd=%d on parent fd=%d)\n", ret, fd);
+	udtrace_add_fd_child(fd, ret);
 }
 
 void sock_ev_accept4(int fd, int ret, int err, struct sockaddr *addr,
@@ -93,7 +94,8 @@ void sock_ev_accept4(int fd, int ret, int err, struct sockaddr *addr,
 {
 	if (ret < 0)
 		return;
-	udtrace_add_fd(ret);
+	LOG("accept(fd=%d on parent fd=%d)\n", ret, fd);
+	udtrace_add_fd_child(fd, ret);
 }
 
 void sock_ev_send(int fd, int ret, int err, const void *buf, size_t bytes,

--- a/utils.c
+++ b/utils.c
@@ -85,6 +85,32 @@ void udtrace_add_fd(int fd)
 	ss->fd = fd;
 }
 
+/* add a file descriptor from the list of to-be-traced ones */
+void udtrace_add_fd_child(int pfd, int cfd)
+{
+	struct sock_state *pss, *css;
+
+	/* Find the parent socket state first */
+	pss = udtrace_sstate_by_fd(pfd);
+	if (!pss) {
+		LOG("Couldn't find parent UNIX FD %d for %d\n", pfd, cfd);
+		return;
+	}
+
+	/* Find an unused state in unix_fds */
+	css = udtrace_sstate_by_fd(-1);
+	if (!css) {
+		LOG("Couldn't add UNIX FD %d (no space in unix_fds)\n", cfd);
+		return;
+	}
+
+	LOG("Adding FD %d as a child of %d\n", cfd, pfd);
+
+	css->dissector = pss->dissector;
+	css->path = strdup(pss->path);
+	css->fd = cfd;
+}
+
 /* delete a file descriptor from the list of to-be-traced ones */
 void udtrace_del_fd(int fd)
 {

--- a/utils.c
+++ b/utils.c
@@ -47,18 +47,10 @@ static char *hexdump(const unsigned char *buf, int len, char *delim)
 	return hexd_buff;
 }
 
-typedef void (*udtrace_dissector)(int fd, bool is_out, const char *fn, const uint8_t *data, unsigned int len);
-
 static void default_dissector(int fd, bool is_out, const char *fn, const uint8_t *data, unsigned int len)
 {
 	fprintf(stderr, "%d %s %c %s\n", fd, fn, is_out ? 'W' : 'R', hexdump(data, len, ""));
 }
-
-struct sock_state {
-	int fd;
-	const char *path;
-	udtrace_dissector dissector;
-};
 
 static struct sock_state unix_fds[MAX_UNIX_FDS];
 

--- a/utils.c
+++ b/utils.c
@@ -133,7 +133,7 @@ void udtrace_fd_set_path(int fd, const char *path)
 	}
 }
 
-const struct sock_state *udtrace_sstate_by_fd(int fd)
+struct sock_state *udtrace_sstate_by_fd(int fd)
 {
 	int i;
 	for (i = 0; i < ARRAY_SIZE(unix_fds); i++) {
@@ -154,7 +154,7 @@ bool is_unix_socket(int fd)
 
 void udtrace_data(int fd, bool is_out, const char *fn, const uint8_t *data, unsigned int len)
 {
-	const struct sock_state *ss = udtrace_sstate_by_fd(fd);
+	struct sock_state *ss = udtrace_sstate_by_fd(fd);
 	if (!data || !len || !ss)
 		return;
 	ss->dissector(fd, is_out, fn, data, len);

--- a/utils.h
+++ b/utils.h
@@ -21,6 +21,9 @@ struct sock_state *udtrace_sstate_by_fd(int fd);
 /* add a file descriptor from the list of to-be-traced ones */
 void udtrace_add_fd(int fd);
 
+/* add a file descriptor from the list of to-be-traced ones */
+void udtrace_add_fd_child(int pfd, int cfd);
+
 /* delete a file descriptor from the list of to-be-traced ones */
 void udtrace_del_fd(int fd);
 

--- a/utils.h
+++ b/utils.h
@@ -6,6 +6,9 @@
 #define LOG(fmt, args ...) \
 	fprintf(stderr, ">>> UDTRACE: " fmt, ## args)
 
+/* find the state corresponding to a given file descriptor */
+struct sock_state *udtrace_sstate_by_fd(int fd);
+
 /* add a file descriptor from the list of to-be-traced ones */
 void udtrace_add_fd(int fd);
 

--- a/utils.h
+++ b/utils.h
@@ -6,6 +6,15 @@
 #define LOG(fmt, args ...) \
 	fprintf(stderr, ">>> UDTRACE: " fmt, ## args)
 
+typedef void (*udtrace_dissector)(int fd, bool is_out, const char *fn,
+	const uint8_t *data, unsigned int len);
+
+struct sock_state {
+	int fd;
+	const char *path;
+	udtrace_dissector dissector;
+};
+
 /* find the state corresponding to a given file descriptor */
 struct sock_state *udtrace_sstate_by_fd(int fd);
 


### PR DESCRIPTION
In some applications, such as OsmocomBB, a single UNIX socket
can be used by multiple processes (i.e. a server and multiple
clients). Previously this caused a segmentation fault.

It makes sense to track such 'parent-child' file descriptor relations,
and reuse both  socket path and dissector from the parent.